### PR TITLE
make compatible with new 2.0.7 API of evcc and optimise pull amount

### DIFF
--- a/Volvo4evcc.psd1
+++ b/Volvo4evcc.psd1
@@ -4,7 +4,7 @@
     RootModule = 'Volvo4evcc.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.1.1'
+    ModuleVersion = '2.2.0'
     
     # ID used to uniquely identify this module
     GUID = '50047ffd-8482-4a42-94f3-52bbf7515d93'


### PR DESCRIPTION
make compatible with new 2.0.7 API of evcc 
optimise pull amount by reducing tokecn checks when not needed. 
This does nolonger keep the token hot and only refreshes token when needed. 

Note token is still max 7 days due to Volvo`s security , i am trying to contact them to see if there is anything to do to strech this back to a month